### PR TITLE
feat: remove aws version limit and bump internally

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -182,43 +182,43 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.19.12"
+version = "1.28.10"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
-python-versions = ">= 3.6"
+python-versions = ">= 3.7"
 files = [
-    {file = "boto3-1.19.12-py3-none-any.whl", hash = "sha256:b9105554477978e80fda1103ff21ecf07502080667730e45383e1d3951c87954"},
-    {file = "boto3-1.19.12.tar.gz", hash = "sha256:182a2b756a2c2180b473bc8452227062394a24e3701548be23ebc30d85976c64"},
+    {file = "boto3-1.28.10-py3-none-any.whl", hash = "sha256:67001b3f512cbe2e00e352c65fb443b504e5e388fee39d73bcc42da1ae87d9e3"},
+    {file = "boto3-1.28.10.tar.gz", hash = "sha256:cb8af03f553f1c7db7137bc897785baeeaa97b8fde483eb1cdb1f1ef3cec9cb7"},
 ]
 
 [package.dependencies]
-botocore = ">=1.22.12,<1.23.0"
-jmespath = ">=0.7.1,<1.0.0"
-s3transfer = ">=0.5.0,<0.6.0"
+botocore = ">=1.31.10,<1.32.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.6.0,<0.7.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.22.12"
+version = "1.31.10"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
-python-versions = ">= 3.6"
+python-versions = ">= 3.7"
 files = [
-    {file = "botocore-1.22.12-py3-none-any.whl", hash = "sha256:1d1094fb53ebe4535d8840fbd7c14aadb65bde7ff03a65f9a4f1d76bd03e16ff"},
-    {file = "botocore-1.22.12.tar.gz", hash = "sha256:fc59b55e8c5dde64b017b2f114c25f8cce397b667e812aea7eafb4b59b49d7cb"},
+    {file = "botocore-1.31.10-py3-none-any.whl", hash = "sha256:a3bfd3627a490faedf37d79373d6957936d7720888ca85466e0471cb921e4557"},
+    {file = "botocore-1.31.10.tar.gz", hash = "sha256:736a9412f405d6985570c4a87b533c2396dd8d4042d8c7a0ca14e73d4f1bcf9d"},
 ]
 
 [package.dependencies]
-jmespath = ">=0.7.1,<1.0.0"
+jmespath = ">=0.7.1,<2.0.0"
 python-dateutil = ">=2.1,<3.0.0"
 urllib3 = ">=1.25.4,<1.27"
 
 [package.extras]
-crt = ["awscrt (==0.12.5)"]
+crt = ["awscrt (==0.16.26)"]
 
 [[package]]
 name = "cached-property"
@@ -2721,14 +2721,14 @@ files = [
 
 [[package]]
 name = "s3transfer"
-version = "0.5.2"
+version = "0.6.1"
 description = "An Amazon S3 Transfer Manager"
 category = "main"
 optional = false
-python-versions = ">= 3.6"
+python-versions = ">= 3.7"
 files = [
-    {file = "s3transfer-0.5.2-py3-none-any.whl", hash = "sha256:7a6f4c4d1fdb9a2b640244008e142cbc2cd3ae34b386584ef044dd0f27101971"},
-    {file = "s3transfer-0.5.2.tar.gz", hash = "sha256:95c58c194ce657a5f4fb0b9e60a84968c808888aed628cd98ab8771fe1db98ed"},
+    {file = "s3transfer-0.6.1-py3-none-any.whl", hash = "sha256:3c0da2d074bf35d6870ef157158641178a4204a6e689e82546083e31e0311346"},
+    {file = "s3transfer-0.6.1.tar.gz", hash = "sha256:640bb492711f4c0c0905e1f62b6aaeb771881935ad27884852411f8e9cacbca9"},
 ]
 
 [package.dependencies]
@@ -3217,4 +3217,4 @@ thycotic = ["python-tss-sdk"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "b2f5711720bfe6608e3d0c55f2888dd77a2ce584ab13fc288e392a15944a030b"
+content-hash = "7502390153dff8a8df62a8cf4ec31e7123241b454fb6a3433d393347713c3ee8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,10 @@ nautobot = "^1.4.0"
 
 #
 # Optional dependencies installed as extras
-# 
+#
 
 # AWS SDK for Python (always keep in sync w/ dev dependency)
-boto3 = { version = "~1.19.5", optional = true }
+boto3 = { version = ">=1.19.0", optional = true }
 # HashiCorp Vault API Client (always keep in sync w/ dev dependency)
 hvac = { version = ">=0.11.0, <1.1.0", optional = true }
 # Thycotic Secret Server (always keep in sync w/ dev dependency)
@@ -36,7 +36,7 @@ python-tss-sdk = {version = "~1.2.0", optional = true}
 [tool.poetry.dev-dependencies]
 bandit = "*"
 black = "*"
-boto3 = "~1.19.5"  # (always keep in sync w/ optional dependency)
+boto3 = ">=1.19.0"  # (always keep in sync w/ optional dependency)
 coverage = "~6.2"
 django-debug-toolbar = "*"
 flake8 = ">=3.9.2"


### PR DESCRIPTION
If you want to use a higher boto3 version in your nautboto environment you cannot do it because it was hardly restricted to an 2021 version