### PR TITLE
Fix/issue64 - added fallthrough in error handling

### DIFF
--- a/changes/64.added
+++ b/changes/64.added
@@ -1,0 +1,1 @@
+Added fallthrough for boto3 error handling to catch errors not explicitly defined.

--- a/development/docker-compose.mysql.yml
+++ b/development/docker-compose.mysql.yml
@@ -19,7 +19,6 @@ services:
   db:
     image: "mysql:8"
     command:
-      - "--default-authentication-plugin=mysql_native_password"
       - "--max_connections=1000"
     env_file:
       - "development.env"

--- a/nautobot_secrets_providers/providers/aws.py
+++ b/nautobot_secrets_providers/providers/aws.py
@@ -83,6 +83,9 @@ class AWSSecretsManagerSecretsProvider(SecretsProvider):
                 # We can't find the resource that you asked for.
                 # Deal with the exception here, and/or rethrow at your discretion.
                 raise exceptions.SecretValueNotFoundError(secret, cls, str(err))
+            else:
+                # We got an error that isn't defined above
+                raise exceptions.SecretProviderError(secret, cls, str(err))
         else:
             # Decrypts secret using the associated KMS CMK.
             # Depending on whether the secret is a string or binary, one of these fields will be populated.


### PR DESCRIPTION
The boto3 call to get the secret value is wrapped in a try/except.  The except block has a switch statement to raise different exceptions based on the error content.  There was no fallthrough for the switch, so errors that were not explicitly defined were masked behind a subsequent error about the secret_value being referenced before it was assigned.